### PR TITLE
Force approve tokens in CCTP relayer

### DIFF
--- a/CCTPRelayer/src/CCTPRelayer.sol
+++ b/CCTPRelayer/src/CCTPRelayer.sol
@@ -157,7 +157,7 @@ contract CCTPRelayer is ICCTPRelayer, Initializable, UUPSUpgradeable, Ownable2St
             token.safeTransferFrom(msg.sender, address(this), inputAmount);
 
             // Approve the swap router to spend the input tokens
-            token.approve(swapRouter, inputAmount);
+            token.forceApprove(swapRouter, inputAmount);
 
             // Call the swap router and perform the swap
             (bool success,) = swapRouter.call(swapCalldata);
@@ -177,7 +177,7 @@ contract CCTPRelayer is ICCTPRelayer, Initializable, UUPSUpgradeable, Ownable2St
                 token.safeTransfer(msg.sender, dust);
 
                 // Revoke Approval
-                token.approve(swapRouter, 0);
+                token.forceApprove(swapRouter, 0);
             }
         }
 
@@ -246,7 +246,7 @@ contract CCTPRelayer is ICCTPRelayer, Initializable, UUPSUpgradeable, Ownable2St
             token.safeTransferFrom(msg.sender, address(this), inputAmount);
 
             // Approve the swap router to spend the input tokens
-            token.approve(swapRouter, inputAmount);
+            token.forceApprove(swapRouter, inputAmount);
 
             // Call the swap router and perform the swap
             (bool success,) = swapRouter.call(swapCalldata);
@@ -266,7 +266,7 @@ contract CCTPRelayer is ICCTPRelayer, Initializable, UUPSUpgradeable, Ownable2St
                 token.safeTransfer(msg.sender, dust);
 
                 // Revoke Approval
-                token.approve(swapRouter, 0);
+                token.forceApprove(swapRouter, 0);
             }
         }
 


### PR DESCRIPTION
Updates token approvals in CCTP relayer to use the `SafeERC20.forceApprove` function in order to work with USDT. We we `.safeApprove` in the Axelar contract however it looks like that has been deprecated and forceApprove effectively does the same thing.