### PR TITLE
[API-3250] extend cctp contract functions to take an expiry timestamp and a memo

### DIFF
--- a/CCTPRelayer/src/CCTPRelayer.sol
+++ b/CCTPRelayer/src/CCTPRelayer.sol
@@ -131,66 +131,9 @@ contract CCTPRelayer is ICCTPRelayer, Initializable, UUPSUpgradeable, Ownable2St
 
         uint256 outputAmount;
         if (inputToken == address(0)) {
-            IERC20 token = IERC20(inputToken);
-
-            // Native Token
-            if (inputAmount != msg.value) revert InsufficientNativeToken();
-
-            // Get the contract's balances previous to the swap
-            uint256 preInputBalance = address(this).balance - inputAmount;
-            uint256 preOutputBalance = usdc.balanceOf(address(this));
-
-            // Call the swap router and perform the swap
-            (bool success,) = swapRouter.call{value: inputAmount}(swapCalldata);
-            if (!success) revert SwapFailed();
-
-            // Get the contract's balances after the swap
-            uint256 postInputBalance = address(this).balance;
-            uint256 postOutputBalance = usdc.balanceOf(address(this));
-
-            // Check that the contract's native token balance has increased
-            if (preOutputBalance >= postOutputBalance) revert InsufficientSwapOutput();
-            outputAmount = postOutputBalance - preOutputBalance;
-
-            // Refund the remaining ETH
-            uint256 dust = postInputBalance - preInputBalance;
-            if (dust != 0) {
-                (bool ethSuccess,) = msg.sender.call{value: dust}("");
-                if (!ethSuccess) revert ETHSendFailed();
-            }
+            outputAmount = _swapNativeAndReturnDust(inputAmount, swapCalldata);
         } else {
-            IERC20 token = IERC20(inputToken);
-
-            // Get the contract's balances previous to the swap
-            uint256 preInputBalance = token.balanceOf(address(this));
-            uint256 preOutputBalance = usdc.balanceOf(address(this));
-
-            // Transfer input ERC20 tokens to the contract
-            token.transferFrom(msg.sender, address(this), inputAmount);
-
-            // Approve the swap router to spend the input tokens
-            token.approve(swapRouter, inputAmount);
-
-            // Call the swap router and perform the swap
-            (bool success,) = swapRouter.call(swapCalldata);
-            if (!success) revert SwapFailed();
-
-            // Get the contract's balances after the swap
-            uint256 postInputBalance = token.balanceOf(address(this));
-            uint256 postOutputBalance = usdc.balanceOf(address(this));
-
-            // Check that the contract's output token balance has increased
-            if (preOutputBalance >= postOutputBalance) revert InsufficientSwapOutput();
-            outputAmount = postOutputBalance - preOutputBalance;
-
-            // Refund the remaining amount
-            uint256 dust = postInputBalance - preInputBalance;
-            if (dust != 0) {
-                token.transfer(msg.sender, dust);
-
-                // Revoke Approval
-                token.approve(swapRouter, 0);
-            }
+            outputAmount = _swapAndReturnDust(inputToken, inputAmount, swapCalldata);
         }
 
         // Check that output amount is enough to cover the fee
@@ -224,66 +167,9 @@ contract CCTPRelayer is ICCTPRelayer, Initializable, UUPSUpgradeable, Ownable2St
 
         uint256 outputAmount;
         if (inputToken == address(0)) {
-            // Native Token
-            if (inputAmount != msg.value) revert InsufficientNativeToken();
-
-            IERC20 token = IERC20(inputToken);
-
-            // Get the contract's balances previous to the swap
-            uint256 preInputBalance = address(this).balance - inputAmount;
-            uint256 preOutputBalance = usdc.balanceOf(address(this));
-
-            // Call the swap router and perform the swap
-            (bool success,) = swapRouter.call{value: inputAmount}(swapCalldata);
-            if (!success) revert SwapFailed();
-
-            // Get the contract's balances after the swap
-            uint256 postInputBalance = address(this).balance;
-            uint256 postOutputBalance = usdc.balanceOf(address(this));
-
-            // Check that the contract's native token balance has increased
-            if (preOutputBalance >= postOutputBalance) revert InsufficientSwapOutput();
-            outputAmount = postOutputBalance - preOutputBalance;
-
-            // Refund the remaining ETH
-            uint256 dust = postInputBalance - preInputBalance;
-            if (dust != 0) {
-                (bool ethSuccess,) = msg.sender.call{value: dust}("");
-                if (!ethSuccess) revert ETHSendFailed();
-            }
+            outputAmount = _swapNativeAndReturnDust(inputAmount, swapCalldata);
         } else {
-            IERC20 token = IERC20(inputToken);
-
-            // Get the contract's balances previous to the swap
-            uint256 preInputBalance = token.balanceOf(address(this));
-            uint256 preOutputBalance = usdc.balanceOf(address(this));
-
-            // Transfer input ERC20 tokens to the contract
-            token.transferFrom(msg.sender, address(this), inputAmount);
-
-            // Approve the swap router to spend the input tokens
-            token.approve(swapRouter, inputAmount);
-
-            // Call the swap router and perform the swap
-            (bool success,) = swapRouter.call(swapCalldata);
-            if (!success) revert SwapFailed();
-
-            // Get the contract's balances after the swap
-            uint256 postInputBalance = token.balanceOf(address(this));
-            uint256 postOutputBalance = usdc.balanceOf(address(this));
-
-            // Check that the contract's output token balance has increased
-            if (preOutputBalance >= postOutputBalance) revert InsufficientSwapOutput();
-            outputAmount = postOutputBalance - preOutputBalance;
-
-            // Refund the remaining amount
-            uint256 dust = postInputBalance - preInputBalance;
-            if (dust != 0) {
-                token.transfer(msg.sender, dust);
-
-                // Revoke Approval
-                token.approve(swapRouter, 0);
-            }
+            outputAmount = _swapAndReturnDust(inputToken, inputAmount, swapCalldata);
         }
 
         // Check that output amount is enough to cover the fee
@@ -335,4 +221,73 @@ contract CCTPRelayer is ICCTPRelayer, Initializable, UUPSUpgradeable, Ownable2St
     receive() external payable {}
 
     function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
+
+    function _swapAndReturnDust(address inputToken, uint256 inputAmount, bytes memory swapCalldata)
+        internal
+        returns (uint256 outputAmount)
+    {
+        IERC20 token = IERC20(inputToken);
+
+        // Get the contract's balances previous to the swap
+        uint256 preInputBalance = token.balanceOf(address(this));
+        uint256 preOutputBalance = usdc.balanceOf(address(this));
+
+        // Transfer input ERC20 tokens to the contract
+        token.transferFrom(msg.sender, address(this), inputAmount);
+
+        // Approve the swap router to spend the input tokens
+        token.approve(swapRouter, inputAmount);
+
+        // Call the swap router and perform the swap
+        (bool success,) = swapRouter.call(swapCalldata);
+        if (!success) revert SwapFailed();
+
+        // Get the contract's balances after the swap
+        uint256 postInputBalance = token.balanceOf(address(this));
+        uint256 postOutputBalance = usdc.balanceOf(address(this));
+
+        // Check that the contract's output token balance has increased
+        if (preOutputBalance >= postOutputBalance) revert InsufficientSwapOutput();
+        outputAmount = postOutputBalance - preOutputBalance;
+
+        // Refund the remaining amount
+        uint256 dust = postInputBalance - preInputBalance;
+        if (dust != 0) {
+            token.transfer(msg.sender, dust);
+
+            // Revoke Approval
+            token.approve(swapRouter, 0);
+        }
+    }
+
+    function _swapNativeAndReturnDust(uint256 inputAmount, bytes memory swapCalldata)
+        internal
+        returns (uint256 outputAmount)
+    {
+        // Native Token
+        if (inputAmount != msg.value) revert InsufficientNativeToken();
+
+        // Get the contract's balances previous to the swap
+        uint256 preInputBalance = address(this).balance - inputAmount;
+        uint256 preOutputBalance = usdc.balanceOf(address(this));
+
+        // Call the swap router and perform the swap
+        (bool success,) = swapRouter.call{value: inputAmount}(swapCalldata);
+        if (!success) revert SwapFailed();
+
+        // Get the contract's balances after the swap
+        uint256 postInputBalance = address(this).balance;
+        uint256 postOutputBalance = usdc.balanceOf(address(this));
+
+        // Check that the contract's native token balance has increased
+        if (preOutputBalance >= postOutputBalance) revert InsufficientSwapOutput();
+        outputAmount = postOutputBalance - preOutputBalance;
+
+        // Refund the remaining ETH
+        uint256 dust = postInputBalance - preInputBalance;
+        if (dust != 0) {
+            (bool ethSuccess,) = msg.sender.call{value: dust}("");
+            if (!ethSuccess) revert ETHSendFailed();
+        }
+    }
 }

--- a/CCTPRelayer/src/CCTPRelayer.sol
+++ b/CCTPRelayer/src/CCTPRelayer.sol
@@ -55,13 +55,13 @@ contract CCTPRelayer is ICCTPRelayer, Initializable, UUPSUpgradeable, Ownable2St
         swapRouter = _swapRouter;
     }
 
-    function makePaymentForRelay(uint64 nonce, uint256 paymentAmount, string memory relayQuoteToken) external {
+    function makePaymentForRelay(uint64 nonce, uint256 paymentAmount, string memory memo) external {
         if (paymentAmount == 0) revert PaymentCannotBeZero();
         // Transfer the funds from the user into the contract and fail if the transfer reverts.
         if (!usdc.transferFrom(msg.sender, address(this), paymentAmount)) revert TransferFailed();
 
         // If the transfer succeeds, emit the payment event.
-        emit PaymentForRelay(nonce, paymentAmount, relayQuoteToken);
+        emit PaymentForRelay(nonce, paymentAmount, memo);
     }
 
     function requestCCTPTransfer(
@@ -71,7 +71,7 @@ contract CCTPRelayer is ICCTPRelayer, Initializable, UUPSUpgradeable, Ownable2St
         address burnToken,
         uint256 feeAmount,
         uint256 expiryTimestamp,
-        string memory relayQuoteToken
+        string memory memo
     ) external withExpiry(expiryTimestamp) {
         if (transferAmount == 0) revert PaymentCannotBeZero();
         if (feeAmount == 0) revert PaymentCannotBeZero();
@@ -85,7 +85,7 @@ contract CCTPRelayer is ICCTPRelayer, Initializable, UUPSUpgradeable, Ownable2St
         uint64 nonce = messenger.depositForBurn(transferAmount, destinationDomain, mintRecipient, burnToken);
 
         // As user already paid for the fee we emit the payment event.
-        emit PaymentForRelay(nonce, feeAmount, relayQuoteToken);
+        emit PaymentForRelay(nonce, feeAmount, memo);
     }
 
     function requestCCTPTransferWithCaller(
@@ -96,7 +96,7 @@ contract CCTPRelayer is ICCTPRelayer, Initializable, UUPSUpgradeable, Ownable2St
         uint256 feeAmount,
         bytes32 destinationCaller,
         uint256 expiryTimestamp,
-        string memory relayQuoteToken
+        string memory memo
     ) external withExpiry(expiryTimestamp) {
         if (transferAmount == 0) revert PaymentCannotBeZero();
         if (feeAmount == 0) revert PaymentCannotBeZero();
@@ -112,7 +112,7 @@ contract CCTPRelayer is ICCTPRelayer, Initializable, UUPSUpgradeable, Ownable2St
         );
 
         // As user already paid for the fee we emit the payment event.
-        emit PaymentForRelay(nonce, feeAmount, relayQuoteToken);
+        emit PaymentForRelay(nonce, feeAmount, memo);
     }
 
     function swapAndRequestCCTPTransfer(
@@ -124,7 +124,7 @@ contract CCTPRelayer is ICCTPRelayer, Initializable, UUPSUpgradeable, Ownable2St
         address burnToken,
         uint256 feeAmount,
         uint256 expiryTimestamp,
-        string memory relayQuoteToken
+        string memory memo
     ) external payable nonReentrant withExpiry(expiryTimestamp) {
         if (inputAmount == 0) revert PaymentCannotBeZero();
         if (feeAmount == 0) revert PaymentCannotBeZero();
@@ -147,7 +147,7 @@ contract CCTPRelayer is ICCTPRelayer, Initializable, UUPSUpgradeable, Ownable2St
         uint64 nonce = messenger.depositForBurn(transferAmount, destinationDomain, mintRecipient, burnToken);
 
         // As user already paid for the fee we emit the payment event.
-        emit PaymentForRelay(nonce, feeAmount, relayQuoteToken);
+        emit PaymentForRelay(nonce, feeAmount, memo);
     }
 
     function swapAndRequestCCTPTransferWithCaller(
@@ -160,7 +160,7 @@ contract CCTPRelayer is ICCTPRelayer, Initializable, UUPSUpgradeable, Ownable2St
         uint256 feeAmount,
         bytes32 destinationCaller,
         uint256 expiryTimestamp,
-        string memory relayQuoteToken
+        string memory memo
     ) external payable nonReentrant withExpiry(expiryTimestamp) {
         if (inputAmount == 0) revert PaymentCannotBeZero();
         if (feeAmount == 0) revert PaymentCannotBeZero();
@@ -185,7 +185,7 @@ contract CCTPRelayer is ICCTPRelayer, Initializable, UUPSUpgradeable, Ownable2St
         );
 
         // As user already paid for the fee we emit the payment event.
-        emit PaymentForRelay(nonce, feeAmount, relayQuoteToken);
+        emit PaymentForRelay(nonce, feeAmount, memo);
     }
 
     function batchReceiveMessage(ICCTPRelayer.ReceiveCall[] memory receiveCalls) external {

--- a/CCTPRelayer/src/interfaces/ICCTPRelayer.sol
+++ b/CCTPRelayer/src/interfaces/ICCTPRelayer.sol
@@ -16,7 +16,9 @@ interface ICCTPRelayer {
     error InsufficientNativeToken();
     error Reentrancy();
 
-    event PaymentForRelay(uint64 nonce, uint256 paymentAmount, string relayQuoteToken);
+    event PaymentForRelay(uint64 nonce, uint256 paymentAmount);
+    
+    event RelayMemo(string memo);
 
     event FailedReceiveMessage(bytes message, bytes attestation);
 
@@ -25,15 +27,13 @@ interface ICCTPRelayer {
         bytes attestation;
     }
 
-    function makePaymentForRelay(uint64 nonce, uint256 paymentAmount, string memory relayQuoteToken) external;
+    function makePaymentForRelay(uint64 nonce, uint256 paymentAmount) external;
 
     function requestCCTPTransfer(
         uint256 transferAmount,
         uint32 destinationDomain,
         bytes32 mintRecipient,
         address burnToken,
-        uint256 feeAmount,
-        uint256 expiryTimestamp,
-        string memory relayQuoteToken
+        uint256 feeAmount
     ) external;
 }

--- a/CCTPRelayer/src/interfaces/ICCTPRelayer.sol
+++ b/CCTPRelayer/src/interfaces/ICCTPRelayer.sol
@@ -16,7 +16,7 @@ interface ICCTPRelayer {
     error InsufficientNativeToken();
     error Reentrancy();
 
-    event PaymentForRelay(uint64 nonce, uint256 paymentAmount);
+    event PaymentForRelay(uint64 nonce, uint256 paymentAmount, string relayQuoteToken);
 
     event FailedReceiveMessage(bytes message, bytes attestation);
 
@@ -25,13 +25,15 @@ interface ICCTPRelayer {
         bytes attestation;
     }
 
-    function makePaymentForRelay(uint64 nonce, uint256 paymentAmount) external;
+    function makePaymentForRelay(uint64 nonce, uint256 paymentAmount, string memory relayQuoteToken) external;
 
     function requestCCTPTransfer(
         uint256 transferAmount,
         uint32 destinationDomain,
         bytes32 mintRecipient,
         address burnToken,
-        uint256 feeAmount
+        uint256 feeAmount,
+        uint256 expiryTimestamp,
+        string memory relayQuoteToken
     ) external;
 }

--- a/CCTPRelayer/test/CCTPRelayer.t.sol
+++ b/CCTPRelayer/test/CCTPRelayer.t.sol
@@ -281,7 +281,7 @@ contract CCTPRelayerTest is Test {
 
             vm.startPrank(ACTOR_1);
             relayer.swapAndRequestCCTPTransfer{value: inputAmount}(
-                inputToken, inputAmount, swapCalldata, domain, mintRecipent, address(usdc), feeAmount
+                inputToken, inputAmount, swapCalldata, domain, mintRecipent, address(usdc), feeAmount, 0, ""
             );
             vm.stopPrank();
 
@@ -296,7 +296,7 @@ contract CCTPRelayerTest is Test {
             vm.startPrank(ACTOR_1);
             IERC20(inputToken).approve(address(relayer), inputAmount);
             relayer.swapAndRequestCCTPTransfer(
-                inputToken, inputAmount, swapCalldata, domain, mintRecipent, address(usdc), feeAmount
+                inputToken, inputAmount, swapCalldata, domain, mintRecipent, address(usdc), feeAmount, 0, ""
             );
             vm.stopPrank();
 
@@ -336,7 +336,9 @@ contract CCTPRelayerTest is Test {
                 mintRecipent,
                 address(usdc),
                 feeAmount,
-                keccak256(abi.encodePacked("random caller"))
+                keccak256(abi.encodePacked("random caller")),
+                0,
+                ""
             );
             vm.stopPrank();
 
@@ -358,7 +360,9 @@ contract CCTPRelayerTest is Test {
                 mintRecipent,
                 address(usdc),
                 feeAmount,
-                keccak256(abi.encodePacked("random caller"))
+                keccak256(abi.encodePacked("random caller")),
+                0,
+                ""
             );
             vm.stopPrank();
 
@@ -401,7 +405,7 @@ contract CCTPRelayerTest is Test {
 
         vm.startPrank(ACTOR_1);
         usdc.approve(address(relayer), amount);
-        relayer.requestCCTPTransfer(transferAmount, domain, mintRecipent, address(usdc), feeAmount);
+        relayer.requestCCTPTransfer(transferAmount, domain, mintRecipent, address(usdc), feeAmount, 0, "");
         vm.stopPrank();
 
         assertEq(usdc.allowance(address(relayer), address(messenger)), 0, "Messenger Allowance Remaining After Payment");
@@ -422,7 +426,7 @@ contract CCTPRelayerTest is Test {
         vm.startPrank(ACTOR_1);
         usdc.approve(address(relayer), amount);
         relayer.requestCCTPTransferWithCaller(
-            transferAmount, domain, mintRecipent, address(usdc), feeAmount, keccak256(abi.encodePacked("random caller"))
+            transferAmount, domain, mintRecipent, address(usdc), feeAmount, keccak256(abi.encodePacked("random caller")), 0, ""
         );
         vm.stopPrank();
 
@@ -470,7 +474,7 @@ contract CCTPRelayerTest is Test {
 
         vm.startPrank(ACTOR_1);
         usdc.approve(address(relayer), amount);
-        relayer.makePaymentForRelay(nonce, amount);
+        relayer.makePaymentForRelay(nonce, amount, "");
         vm.stopPrank();
 
         assertEq(usdc.allowance(ACTOR_1, address(relayer)), 0, "Allowance Remaining After Payment");

--- a/CCTPRelayer/test/CCTPRelayer.t.sol
+++ b/CCTPRelayer/test/CCTPRelayer.t.sol
@@ -281,7 +281,7 @@ contract CCTPRelayerTest is Test {
 
             vm.startPrank(ACTOR_1);
             relayer.swapAndRequestCCTPTransfer{value: inputAmount}(
-                inputToken, inputAmount, swapCalldata, domain, mintRecipent, address(usdc), feeAmount, 0, ""
+                inputToken, inputAmount, swapCalldata, domain, mintRecipent, address(usdc), feeAmount
             );
             vm.stopPrank();
 
@@ -296,7 +296,7 @@ contract CCTPRelayerTest is Test {
             vm.startPrank(ACTOR_1);
             IERC20(inputToken).approve(address(relayer), inputAmount);
             relayer.swapAndRequestCCTPTransfer(
-                inputToken, inputAmount, swapCalldata, domain, mintRecipent, address(usdc), feeAmount, 0, ""
+                inputToken, inputAmount, swapCalldata, domain, mintRecipent, address(usdc), feeAmount
             );
             vm.stopPrank();
 
@@ -336,9 +336,7 @@ contract CCTPRelayerTest is Test {
                 mintRecipent,
                 address(usdc),
                 feeAmount,
-                keccak256(abi.encodePacked("random caller")),
-                0,
-                ""
+                keccak256(abi.encodePacked("random caller"))
             );
             vm.stopPrank();
 
@@ -360,9 +358,7 @@ contract CCTPRelayerTest is Test {
                 mintRecipent,
                 address(usdc),
                 feeAmount,
-                keccak256(abi.encodePacked("random caller")),
-                0,
-                ""
+                keccak256(abi.encodePacked("random caller"))
             );
             vm.stopPrank();
 
@@ -405,7 +401,7 @@ contract CCTPRelayerTest is Test {
 
         vm.startPrank(ACTOR_1);
         usdc.approve(address(relayer), amount);
-        relayer.requestCCTPTransfer(transferAmount, domain, mintRecipent, address(usdc), feeAmount, 0, "");
+        relayer.requestCCTPTransfer(transferAmount, domain, mintRecipent, address(usdc), feeAmount);
         vm.stopPrank();
 
         assertEq(usdc.allowance(address(relayer), address(messenger)), 0, "Messenger Allowance Remaining After Payment");
@@ -426,7 +422,7 @@ contract CCTPRelayerTest is Test {
         vm.startPrank(ACTOR_1);
         usdc.approve(address(relayer), amount);
         relayer.requestCCTPTransferWithCaller(
-            transferAmount, domain, mintRecipent, address(usdc), feeAmount, keccak256(abi.encodePacked("random caller")), 0, ""
+            transferAmount, domain, mintRecipent, address(usdc), feeAmount, keccak256(abi.encodePacked("random caller"))
         );
         vm.stopPrank();
 
@@ -474,7 +470,7 @@ contract CCTPRelayerTest is Test {
 
         vm.startPrank(ACTOR_1);
         usdc.approve(address(relayer), amount);
-        relayer.makePaymentForRelay(nonce, amount, "");
+        relayer.makePaymentForRelay(nonce, amount);
         vm.stopPrank();
 
         assertEq(usdc.allowance(ACTOR_1, address(relayer)), 0, "Allowance Remaining After Payment");


### PR DESCRIPTION
Extends cctp contract transfer functions to take two additional arguments:
1. an expiry timestamp we can use to fail transfers if the fee we quote has expired
2. a memo param that just gets emitted in an event
