### PR TITLE
use forceApprove instead of safeApprove

### DIFF
--- a/AxelarHandler/src/GoFastHandler.sol
+++ b/AxelarHandler/src/GoFastHandler.sol
@@ -110,7 +110,7 @@ contract GoFastHandler is Initializable, UUPSUpgradeable, OwnableUpgradeable {
             IERC20(token).safeTransferFrom(msg.sender, address(this), amountIn);
         }
 
-        IERC20(token).safeApprove(address(fastTransferGateway), amountIn);
+        IERC20(token).forceApprove(address(fastTransferGateway), amountIn);
 
         return fastTransferGateway.submitOrder(
             sender, recipient, amountIn, amountOut, destinationDomain, timeoutTimestamp, data
@@ -125,7 +125,7 @@ contract GoFastHandler is Initializable, UUPSUpgradeable, OwnableUpgradeable {
         if (tokenIn != address(0)) {
             IERC20(tokenIn).safeTransferFrom(msg.sender, address(this), amountIn);
 
-            IERC20(tokenIn).safeApprove(address(swapRouter), amountIn);
+            IERC20(tokenIn).forceApprove(address(swapRouter), amountIn);
         }
 
         (bool success,) = address(swapRouter).call{value: msg.value}(swapCalldata);


### PR DESCRIPTION
Discovered a bug for exact out swaps where if the swap doesn't use the entire amount in the token approval is greater than zero afterwards. `safeApprove` expects the allowance to always be zero before calling it. Updated the code to use `forceApprove` which always sets the allowance to zero before calling.