### PR TITLE
support native tokens in EurekaHandler.transfer

### DIFF
--- a/EurekaHandler/src/EurekaHandler.sol
+++ b/EurekaHandler/src/EurekaHandler.sol
@@ -12,8 +12,6 @@ import {IIBCVoucher} from "./interfaces/lombard/IIBCVoucher.sol";
 import {IEurekaHandler} from "./interfaces/IEurekaHandler.sol";
 import {IWETH} from "./interfaces/IWETH.sol";
 
-import {console} from "forge-std/console.sol";
-
 contract EurekaHandler is IEurekaHandler, Initializable, UUPSUpgradeable, OwnableUpgradeable {
     using SafeERC20 for IERC20;
 

--- a/EurekaHandler/src/interfaces/IEurekaHandler.sol
+++ b/EurekaHandler/src/interfaces/IEurekaHandler.sol
@@ -17,7 +17,7 @@ interface IEurekaHandler {
         uint64 quoteExpiry;
     }
 
-    function transfer(uint256 amount, TransferParams memory transferParams, Fees memory fees) external;
+    function transfer(uint256 amount, TransferParams memory transferParams, Fees memory fees) external payable;
 
     function swapAndTransfer(
         address swapInputToken,

--- a/EurekaHandler/src/interfaces/IWETH.sol
+++ b/EurekaHandler/src/interfaces/IWETH.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+interface IWETH {
+    function deposit() external payable;
+
+    function withdraw(uint256 value) external;
+}


### PR DESCRIPTION
Adds support for native tokens in the `transfer` function of the `EurekaHandler`. When `msg.value` is greater than zero, the contract will call `deposit` on the WETH contract to wrap the tokens and then initiate the transfer.

I also adjusted how fees are collected. Previously the contract transferred the fee amount directly from the caller to the relayer address. Now the contract transfers `amount + feeAmount` to the contract, and then transfers the fee amount from the contract to the relayer address.