### PR TITLE
[API-4248] Wrap and unwrap ETH

### DIFF
--- a/SwapRouter/script/Deploy.s.sol
+++ b/SwapRouter/script/Deploy.s.sol
@@ -11,7 +11,9 @@ contract SwapRouterDeploy is Script {
     function run() external {
         vm.startBroadcast();
 
-        SkipGoSwapRouter router = SkipGoSwapRouter(0xa11CC0eFb1B3AcD95a2B8cd316E8c132E16048b5);
+        address weth = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+
+        SkipGoSwapRouter router = new SkipGoSwapRouter(weth);
 
         UniswapV2Adapter uniswapV2Adapter = new UniswapV2Adapter();
         UniswapV3Adapter uniswapV3Adapter = new UniswapV3Adapter();

--- a/SwapRouter/src/SkipGoSwapRouter.sol
+++ b/SwapRouter/src/SkipGoSwapRouter.sol
@@ -7,8 +7,6 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IAdapter} from "./interfaces/IAdapter.sol";
 import {IWETH} from "./interfaces/IWETH.sol";
 
-import {console} from "forge-std/console.sol";
-
 contract SkipGoSwapRouter is Ownable {
     enum ExchangeType {
         UNISWAP_V2,

--- a/SwapRouter/src/adapters/UniswapV2Adapter.sol
+++ b/SwapRouter/src/adapters/UniswapV2Adapter.sol
@@ -13,7 +13,7 @@ contract UniswapV2Adapter {
         uint256 fee;
     }
 
-    function swapExactIn(uint256 amountIn, bytes calldata data) external returns (uint256 amountOut) {
+    function swapExactIn(uint256 amountIn, bytes calldata data) external payable returns (uint256 amountOut) {
         UniswapV2Data memory uniswapV2Data = abi.decode(data, (UniswapV2Data));
 
         (uint112 reserve0, uint112 reserve1,) = IUniswapV2Pair(uniswapV2Data.pool).getReserves();

--- a/SwapRouter/src/adapters/UniswapV3Adapter.sol
+++ b/SwapRouter/src/adapters/UniswapV3Adapter.sol
@@ -15,7 +15,7 @@ contract UniswapV3Adapter {
         address swapRouter;
     }
 
-    function swapExactIn(uint256 amountIn, bytes calldata data) external returns (uint256 amountOut) {
+    function swapExactIn(uint256 amountIn, bytes calldata data) external payable returns (uint256 amountOut) {
         UniswapV3Data memory uniswapV3Data = abi.decode(data, (UniswapV3Data));
 
         IERC20(uniswapV3Data.tokenIn).approve(uniswapV3Data.swapRouter, amountIn);

--- a/SwapRouter/src/interfaces/IWETH.sol
+++ b/SwapRouter/src/interfaces/IWETH.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2015, 2016, 2017 Dapphub
+// Adapted by Ethereum Community 2021
+pragma solidity ^0.8.0;
+
+/// @dev Wrapped Ether v10 (WETH10) is an Ether (ETH) ERC-20 wrapper. You can `deposit` ETH and obtain a WETH10 balance which can then be operated as an ERC-20 token. You can
+/// `withdraw` ETH from WETH10, which will then burn WETH10 token in your wallet. The amount of WETH10 token in any wallet is always identical to the
+/// balance of ETH deposited minus the ETH withdrawn with that specific wallet.
+interface IWETH {
+    /// @dev `msg.value` of ETH sent to this contract grants caller account a matching increase in WETH10 token balance.
+    /// Emits {Transfer} event to reflect WETH10 token mint of `msg.value` from `address(0)` to caller account.
+    function deposit() external payable;
+
+    /// @dev Burn `value` WETH10 token from caller account and withdraw matching ETH to the same.
+    /// Emits {Transfer} event to reflect WETH10 token burn of `value` to `address(0)` from caller account.
+    /// Requirements:
+    ///   - caller account must have at least `value` balance of WETH10 token.
+    function withdraw(uint256 value) external;
+}

--- a/SwapRouter/test/SkipGoSwapRouter.t.sol
+++ b/SwapRouter/test/SkipGoSwapRouter.t.sol
@@ -18,7 +18,7 @@ contract SkipGoSwapRouterTest is Test {
 
         vm.selectFork(mainnetFork);
 
-        router = new SkipGoSwapRouter();
+        router = new SkipGoSwapRouter(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
 
         UniswapV2Adapter uniswapV2Adapter = new UniswapV2Adapter();
         router.addAdapter(SkipGoSwapRouter.ExchangeType.UNISWAP_V2, address(uniswapV2Adapter));
@@ -87,6 +87,132 @@ contract SkipGoSwapRouterTest is Test {
 
         assertEq(wethBalanceAfter, wethBalanceBefore - amountIn);
         assertEq(wbtcBalanceAfter, wbtcBalanceBefore + amountOut);
+
+        assertEq(amountOut, expectedAmountOut);
+    }
+
+    function test_swapExactIn_WithWrapWETH() public {
+        address weth = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+        address usdc = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+        address wbtc = 0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599;
+
+        SkipGoSwapRouter.Affiliate[] memory affiliates = new SkipGoSwapRouter.Affiliate[](0);
+
+        SkipGoSwapRouter.Hop[] memory hops = new SkipGoSwapRouter.Hop[](2);
+
+        {
+            UniswapV2Adapter.UniswapV2Data memory hopOneData = UniswapV2Adapter.UniswapV2Data({
+                pool: 0xB4e16d0168e52d35CaCD2c6185b44281Ec28C9Dc,
+                tokenIn: weth,
+                tokenOut: usdc,
+                fee: 300
+            });
+
+            bytes memory encodedHopOneData = abi.encode(hopOneData);
+
+            hops[0] =
+                SkipGoSwapRouter.Hop({exchangeType: SkipGoSwapRouter.ExchangeType.UNISWAP_V2, data: encodedHopOneData});
+
+            UniswapV3Adapter.UniswapV3Data memory hopTwoData = UniswapV3Adapter.UniswapV3Data({
+                tokenIn: usdc,
+                tokenOut: wbtc,
+                fee: 3000,
+                quoter: 0x5e55C9e631FAE526cd4B0526C4818D6e0a9eF0e3,
+                swapRouter: 0xE592427A0AEce92De3Edee1F18E0157C05861564
+            });
+
+            bytes memory encodedHopTwoData = abi.encode(hopTwoData);
+
+            hops[1] =
+                SkipGoSwapRouter.Hop({exchangeType: SkipGoSwapRouter.ExchangeType.UNISWAP_V3, data: encodedHopTwoData});
+        }
+
+        uint256 amountIn = 1 ether;
+
+        address alice = makeAddr("alice");
+
+        deal(alice, amountIn);
+
+        uint256 expectedAmountOut = router.getAmountOut(amountIn, hops);
+
+        uint256 ethBalanceBefore = address(alice).balance;
+        uint256 wbtcBalanceBefore = IERC20(wbtc).balanceOf(alice);
+
+        vm.startPrank(alice);
+
+        uint256 amountOut = router.swapExactIn{value: amountIn}(amountIn, 1, address(0), wbtc, hops, affiliates);
+
+        vm.stopPrank();
+
+        uint256 ethBalanceAfter = address(alice).balance;
+        uint256 wbtcBalanceAfter = IERC20(wbtc).balanceOf(alice);
+
+        assertEq(ethBalanceAfter, ethBalanceBefore - amountIn);
+        assertEq(wbtcBalanceAfter, wbtcBalanceBefore + amountOut);
+
+        assertEq(amountOut, expectedAmountOut);
+    }
+
+    function test_swapExactIn_WithUnwrapWETH() public {
+        address weth = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+        address usdc = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+        address wbtc = 0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599;
+
+        SkipGoSwapRouter.Affiliate[] memory affiliates = new SkipGoSwapRouter.Affiliate[](0);
+
+        SkipGoSwapRouter.Hop[] memory hops = new SkipGoSwapRouter.Hop[](2);
+
+        {
+            UniswapV3Adapter.UniswapV3Data memory hopOneData = UniswapV3Adapter.UniswapV3Data({
+                tokenIn: wbtc,
+                tokenOut: usdc,
+                fee: 3000,
+                quoter: 0x5e55C9e631FAE526cd4B0526C4818D6e0a9eF0e3,
+                swapRouter: 0xE592427A0AEce92De3Edee1F18E0157C05861564
+            });
+
+            bytes memory encodedHopOneData = abi.encode(hopOneData);
+
+            hops[0] =
+                SkipGoSwapRouter.Hop({exchangeType: SkipGoSwapRouter.ExchangeType.UNISWAP_V3, data: encodedHopOneData});
+
+            UniswapV2Adapter.UniswapV2Data memory hopTwoData = UniswapV2Adapter.UniswapV2Data({
+                pool: 0xB4e16d0168e52d35CaCD2c6185b44281Ec28C9Dc,
+                tokenIn: usdc,
+                tokenOut: weth,
+                fee: 300
+            });
+
+            bytes memory encodedHopTwoData = abi.encode(hopTwoData);
+
+            hops[1] =
+                SkipGoSwapRouter.Hop({exchangeType: SkipGoSwapRouter.ExchangeType.UNISWAP_V2, data: encodedHopTwoData});
+        }
+
+        uint256 amountIn = 1_0000_0000; // 1 BTC
+
+        address alice = makeAddr("alice");
+
+        deal(wbtc, alice, amountIn);
+
+        uint256 expectedAmountOut = router.getAmountOut(amountIn, hops);
+
+        uint256 wbtcBalanceBefore = IERC20(wbtc).balanceOf(alice);
+        uint256 ethBalanceBefore = address(alice).balance;
+
+        vm.startPrank(alice);
+
+        IERC20(wbtc).approve(address(router), amountIn);
+
+        uint256 amountOut = router.swapExactIn(amountIn, 1, wbtc, address(0), hops, affiliates);
+
+        vm.stopPrank();
+
+        uint256 wbtcBalanceAfter = IERC20(wbtc).balanceOf(alice);
+        uint256 ethBalanceAfter = address(alice).balance;
+
+        assertEq(wbtcBalanceAfter, wbtcBalanceBefore - amountIn);
+        assertEq(ethBalanceAfter, ethBalanceBefore + amountOut);
 
         assertEq(amountOut, expectedAmountOut);
     }
@@ -277,6 +403,132 @@ contract SkipGoSwapRouterTest is Test {
 
         assertEq(wethBalanceAfter, wethBalanceBefore - amountIn);
         assertEq(wbtcBalanceAfter, wbtcBalanceBefore + amountOut);
+
+        assertEq(amountIn, expectedAmountIn);
+    }
+
+    function test_swapExactOut_WithWrapWETH() public {
+        address weth = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+        address usdc = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+        address wbtc = 0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599;
+
+        SkipGoSwapRouter.Affiliate[] memory affiliates = new SkipGoSwapRouter.Affiliate[](0);
+
+        SkipGoSwapRouter.Hop[] memory hops = new SkipGoSwapRouter.Hop[](2);
+
+        {
+            UniswapV2Adapter.UniswapV2Data memory hopOneData = UniswapV2Adapter.UniswapV2Data({
+                pool: 0xB4e16d0168e52d35CaCD2c6185b44281Ec28C9Dc,
+                tokenIn: weth,
+                tokenOut: usdc,
+                fee: 300
+            });
+
+            bytes memory encodedHopOneData = abi.encode(hopOneData);
+
+            hops[0] =
+                SkipGoSwapRouter.Hop({exchangeType: SkipGoSwapRouter.ExchangeType.UNISWAP_V2, data: encodedHopOneData});
+
+            UniswapV3Adapter.UniswapV3Data memory hopTwoData = UniswapV3Adapter.UniswapV3Data({
+                tokenIn: usdc,
+                tokenOut: wbtc,
+                fee: 3000,
+                quoter: 0x5e55C9e631FAE526cd4B0526C4818D6e0a9eF0e3,
+                swapRouter: 0xE592427A0AEce92De3Edee1F18E0157C05861564
+            });
+
+            bytes memory encodedHopTwoData = abi.encode(hopTwoData);
+
+            hops[1] =
+                SkipGoSwapRouter.Hop({exchangeType: SkipGoSwapRouter.ExchangeType.UNISWAP_V3, data: encodedHopTwoData});
+        }
+
+        uint256 amountOut = 100000000;
+
+        address alice = makeAddr("alice");
+
+        uint256 expectedAmountIn = router.getAmountIn(amountOut, hops);
+
+        deal(alice, expectedAmountIn + 500);
+
+        uint256 ethBalanceBefore = address(alice).balance;
+        uint256 wbtcBalanceBefore = IERC20(wbtc).balanceOf(alice);
+
+        vm.startPrank(alice);
+
+        // set msg.value greater than expectedAmountIn to ensure dust is returned
+        uint256 amountIn = router.swapExactOut{value: expectedAmountIn + 500}(
+            amountOut, type(uint256).max, address(0), wbtc, hops, affiliates
+        );
+
+        vm.stopPrank();
+
+        uint256 ethBalanceAfter = address(alice).balance;
+        uint256 wbtcBalanceAfter = IERC20(wbtc).balanceOf(alice);
+
+        assertEq(ethBalanceAfter, ethBalanceBefore - amountIn);
+        assertEq(wbtcBalanceAfter, wbtcBalanceBefore + amountOut);
+
+        assertEq(amountIn, expectedAmountIn);
+    }
+
+    function test_swapExactOut_WithUnwrapWETH() public {
+        address weth = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+        address usdc = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+        address wbtc = 0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599;
+
+        SkipGoSwapRouter.Affiliate[] memory affiliates = new SkipGoSwapRouter.Affiliate[](0);
+
+        SkipGoSwapRouter.Hop[] memory hops = new SkipGoSwapRouter.Hop[](2);
+
+        {
+            UniswapV3Adapter.UniswapV3Data memory hopOneData = UniswapV3Adapter.UniswapV3Data({
+                tokenIn: wbtc,
+                tokenOut: usdc,
+                fee: 3000,
+                quoter: 0x5e55C9e631FAE526cd4B0526C4818D6e0a9eF0e3,
+                swapRouter: 0xE592427A0AEce92De3Edee1F18E0157C05861564
+            });
+
+            bytes memory encodedHopOneData = abi.encode(hopOneData);
+
+            hops[0] =
+                SkipGoSwapRouter.Hop({exchangeType: SkipGoSwapRouter.ExchangeType.UNISWAP_V3, data: encodedHopOneData});
+
+            UniswapV2Adapter.UniswapV2Data memory hopTwoData = UniswapV2Adapter.UniswapV2Data({
+                pool: 0xB4e16d0168e52d35CaCD2c6185b44281Ec28C9Dc,
+                tokenIn: usdc,
+                tokenOut: weth,
+                fee: 300
+            });
+
+            bytes memory encodedHopTwoData = abi.encode(hopTwoData);
+
+            hops[1] =
+                SkipGoSwapRouter.Hop({exchangeType: SkipGoSwapRouter.ExchangeType.UNISWAP_V2, data: encodedHopTwoData});
+        }
+
+        uint256 amountOut = 1 ether;
+
+        address alice = makeAddr("alice");
+
+        uint256 expectedAmountIn = router.getAmountIn(amountOut, hops);
+
+        deal(wbtc, alice, expectedAmountIn);
+
+        uint256 wbtcBalanceBefore = IERC20(wbtc).balanceOf(alice);
+
+        vm.startPrank(alice);
+
+        IERC20(wbtc).approve(address(router), expectedAmountIn);
+
+        uint256 amountIn = router.swapExactOut(amountOut, type(uint256).max, wbtc, address(0), hops, affiliates);
+
+        vm.stopPrank();
+
+        uint256 wbtcBalanceAfter = IERC20(wbtc).balanceOf(alice);
+
+        assertEq(wbtcBalanceAfter, wbtcBalanceBefore - amountIn);
 
         assertEq(amountIn, expectedAmountIn);
     }

--- a/SwapRouter/test/adapters/UniswapV2Adapter.t.sol
+++ b/SwapRouter/test/adapters/UniswapV2Adapter.t.sol
@@ -35,7 +35,7 @@ contract UniswapV2AdapterTest is Test {
         deal(tokenIn, alice, amountIn);
 
         UniswapV2Adapter.UniswapV2Data memory data =
-            UniswapV2Adapter.UniswapV2Data({pool: pool, zeroToOne: false, fee: 300});
+            UniswapV2Adapter.UniswapV2Data({pool: pool, tokenIn: tokenIn, tokenOut: tokenOut, fee: 300});
 
         bytes memory encodedData = abi.encode(data);
 


### PR DESCRIPTION
Updates swap router to wrap and unwrap ETH.

- If `tokenIn = address(0)`, convert ETH to WETH
- If `tokenOut = address(0)`, convert WETH to ETH
- For `swapExactOut`, ensure any unused ETH is refunded to the user